### PR TITLE
Fix/ap ssid webserver footer

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -301,6 +301,9 @@ namespace cfg {
 			strcpy(fs_ssid, SSID_BASENAME);
 			strcat(fs_ssid, id);
 		}
+		else{
+			strcat(fs_ssid, id);
+		}
 	}
 }
 

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -11,7 +11,7 @@ const char WWW_PASSWORD[] PROGMEM = "feinstaub";
 #define WWW_BASICAUTH_ENABLED 0
 
 // Sensor Wifi config (config mode)
-#define FS_SSID ""
+#define FS_SSID "sensorsAFRICA-"
 #define FS_PWD ""
 
 // Where to send the data?
@@ -228,7 +228,7 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = " ";
 #endif
 
 // Device is WiFi Enabled
-#define WIFI_ENABLED 1
+#define WIFI_ENABLED 0
 
 //SPH0645 MEMS Microphone
 #define SPHO645_READ  1

--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -71,7 +71,7 @@ const char EMPTY_ROW[] PROGMEM = "<tr><td colspan='3'>&nbsp;</td></tr>";
 
 const char WEB_PAGE_FOOTER[] PROGMEM = "<br/><br/><a href='/' style='display:inline;'>" INTL_BACK_TO_HOME "</a>"\
                 "<br/><br/><br/>"
-                "<a href='https://codefor.de/stuttgart/' target='_blank' rel='noreferrer' style='display:inline;background:none;color:black;box-shadow:none'>&copy; Open Knowledge Lab Stuttgart a.o. (Code for Germany)</a></div></body></html>\r\n";
+                "</div></body></html>\r\n";
 
 const char WEB_ROOT_PAGE_CONTENT[] PROGMEM = "<a href='/values'>{t}</a><br/>\
 <a href='/status'>{s}</a><br/>\


### PR DESCRIPTION
## Description

1. Renamed AP ssid to "sensorsAFRICA-ID".
2. Removed Code for Germany footer trademark.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots
1. Renamed AP
![IMG_1769](https://user-images.githubusercontent.com/33148990/92576502-48474a00-f292-11ea-9c65-f6b1f150d990.jpg)

2. Removed trademark
![IMG_1771](https://user-images.githubusercontent.com/33148990/92576553-54cba280-f292-11ea-9621-92b6175f7e32.jpg)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
