### PR TITLE
Updated platformio libraries

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -44,10 +44,12 @@ lib_deps_generic_external =
   Adafruit SHT31 Library@1.1.6
   ArduinoJson@6.13.0
   DallasTemperature@3.8.0
-  ESP8266_SSD1306@4.1.0
+  thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ 4.1.0 ; updated SSD1306 url
   1655@1.0.2 ; TinyGPSPlus, formerly this was referenced as mikalhart/TinyGPSPlus#v0.95
   797@1.0.1 ; TinyWireM
-
+  https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git ; sensors.AFRICA FONA library 
+  
+  
 ; system libraries from platform -> no version number
 lib_deps_esp8266_platform =
   Hash

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -44,12 +44,12 @@ lib_deps_generic_external =
   Adafruit SHT31 Library@1.1.6
   ArduinoJson@6.13.0
   DallasTemperature@3.8.0
-  thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ 4.1.0 ; updated SSD1306 url
+  ESP8266_SSD1306@4.1.0
   1655@1.0.2 ; TinyGPSPlus, formerly this was referenced as mikalhart/TinyGPSPlus#v0.95
   797@1.0.1 ; TinyWireM
-  https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git ; sensors.AFRICA FONA library 
-  
-  
+  thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ 4.1.0 ; updated SSD1306 url/reference
+  https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git ; sensors.AFRICA FONA library
+
 ; system libraries from platform -> no version number
 lib_deps_esp8266_platform =
   Hash

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -47,7 +47,6 @@ lib_deps_generic_external =
   ESP8266_SSD1306@4.1.0
   1655@1.0.2 ; TinyGPSPlus, formerly this was referenced as mikalhart/TinyGPSPlus#v0.95
   797@1.0.1 ; TinyWireM
-  thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays @ 4.1.0 ; updated SSD1306 url/reference
   https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git ; sensors.AFRICA FONA library
 
 ; system libraries from platform -> no version number


### PR DESCRIPTION
## Description

Add sensors.AFRICA Adafruit FONA library to external lib dependencies and update reference to SSD1306 library for PlatformIO

Fixes #62 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots

![Screenshot (60)](https://github.com/CodeForAfrica/sensors.AFRICA-AQ-sensors-software/assets/17834362/cc31b497-fd53-4c3d-9f2d-666fefa9acd0)

<img width="1072" alt="Screenshot 2023-06-15 180813" src="https://github.com/CodeForAfrica/sensors.AFRICA-AQ-sensors-software/assets/17834362/b7f78222-dff6-457e-b69b-cbd8a7d64f8f">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
